### PR TITLE
doc: fix link paths

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -15,7 +15,7 @@ Make sure you have Rust and Cargo installed
 Clone the repository:
 
 ```sh
-git clone https://github.com/3uild-3thos/poseidon
+git clone https://github.com/Turbin3/poseidon
 ```
 
 Navigate to the project directory:
@@ -42,6 +42,6 @@ Check out examples in the repo to learn how to write Poseidon Typescript which c
 
 ## Tutorial & Examples
 
-Go to [docs/src/tutorial.md](https://github.com/3uild-3thos/poseidon/tree/master/docs/src/tutorial.md) to learn how to write your first Solana program in TypeScript using Poseidon and Anchor!
+Go to [docs/src/tutorial.md](./docs/src/tutorial.md) to learn how to write your first Solana program in TypeScript using Poseidon and Anchor!
 
-For more examples, check out the [examples](https://github.com/3uild-3thos/poseidon/tree/restruct/optimzie-for-tutorial/examples) directory. You’ll find examples of vote, vault, and escrow programs in both TypeScript and the corresponding Rust programs transpiled by Poseidon.
+For more examples, check out the [examples](./examples) directory. You’ll find examples of vote, vault, and escrow programs in both TypeScript and the corresponding Rust programs transpiled by Poseidon.

--- a/docs/src/installation.md
+++ b/docs/src/installation.md
@@ -5,7 +5,7 @@ Make sure you have Rust and Cargo installed
 Clone the repository:
 
 ```sh
-git clone https://github.com/3uild-3thos/poseidon
+git clone https://github.com/Turbin3/poseidon
 ```
 
 Navigate to the project directory:

--- a/docs/src/mapping-into-anchor/README.md
+++ b/docs/src/mapping-into-anchor/README.md
@@ -12,7 +12,7 @@ In this section, we will dive deep into how TypeScript code is mapped to the Anc
 
 ## `Escrow` Program
 
-You can find the code for the `escrow` program in the [`examples/escrow`](https://github.com/3uild-3thos/poseidon/blob/master/examples/escrow/) directory of the Poseidon repository.
+You can find the code for the `escrow` program in the [`examples/escrow`](../../../examples/escrow/) directory of the Poseidon repository.
 
 ### TypeScript (Poseidon)
 

--- a/docs/src/mapping-into-anchor/cpi.md
+++ b/docs/src/mapping-into-anchor/cpi.md
@@ -137,4 +137,4 @@ SystemProgram.transfer(
 );
 ```
 
-Can check the full codebase in the [vault](https://github.com/3uild-3thos/poseidon/blob/master/examples/vault/typescript/vault.ts) example.
+Can check the full codebase in the [vault](../../../examples/vault/typescript/vault.ts) example.

--- a/docs/src/mapping-into-anchor/pda.md
+++ b/docs/src/mapping-into-anchor/pda.md
@@ -69,7 +69,7 @@ pub struct MakeContext<'info> {
 }
 ```
 
-If you're creating a PDA with a given `bump`, you can use the `deriveWithBump` method with the `bump` following the `seed` instead. See the example below or the [vault](https://github.com/3uild-3thos/poseidon/blob/master/examples/vault/typescript/vault.ts) example for more details:
+If you're creating a PDA with a given `bump`, you can use the `deriveWithBump` method with the `bump` following the `seed` instead. See the example below or the [vault](../../../examples/vault/typescript/vault.ts) example for more details:
 
 ```typescript
 auth.deriveWithBump(["auth", state.key], state.authBump);

--- a/docs/src/mapping-into-anchor/state.md
+++ b/docs/src/mapping-into-anchor/state.md
@@ -99,7 +99,7 @@ pub mod escrow_program {
 
 Also if you want to do some arithmetic operations, `@3thos/poseidon` package provides the necessary types for that.
 
-Check out [vote](https://github.com/3uild-3thos/poseidon/blob/master/examples/vote/typescript/vote.ts) example to see how to use them. Here's a snippet from the example:
+Check out [vote](../../../examples/vote/typescript/vote.ts) example to see how to use them. Here's a snippet from the example:
 
 ```typescript
 // initialize the state

--- a/docs/src/tutorial.md
+++ b/docs/src/tutorial.md
@@ -141,7 +141,7 @@ initialize(state: VoteState, user: Signer): Result {
 
 If a user wants to store anything on Solana, such as `VoteState` in this case, they’ll need to pay [rent](https://docs.solanalabs.com/implemented-proposals/rent) for the space they’re using, as validators need to store the data on their hardware. To cover this rent, we add `user` with the `Signer` type as a parameter, allowing the user to transfer their SOL to the `VoteState` account to pay for the rent.
 
-We’ve mentioned PDA several times, but what is it? [PDA](https://solana.com/docs/core/pda) (Program Derived Address) is an important concept on Solana. It allows an account to be controlled by a specified program. To construct a PDA, you need a seed—a byte array that can be derived from a string, public key, integer, or even combinations of these! In this case, we use the string `“vote”` as the seed. You can find more examples of different seed combinations in the provided [examples](https://github.com/3uild-3thos/poseidon/tree/master/examples).
+We’ve mentioned PDA several times, but what is it? [PDA](https://solana.com/docs/core/pda) (Program Derived Address) is an important concept on Solana. It allows an account to be controlled by a specified program. To construct a PDA, you need a seed—a byte array that can be derived from a string, public key, integer, or even combinations of these! In this case, we use the string `“vote”` as the seed. You can find more examples of different seed combinations in the provided [examples](../../examples).
 
 After the state account is initialized, we can assign an initial value, `new i64(0)`, to it.
 
@@ -306,7 +306,7 @@ Here’s the example of the transaction ID ([ApCnLHqiAm...amxDb439jg](https://ex
 
 Congratulations! 🎉 You've completed your first Solana program in TypeScript!
 
-Poseidon helps by transpiling your TypeScript program into Rust using the Anchor framework format. You can check out [examples/vote/rust/vote.rs](https://github.com/3uild-3thos/poseidon/blob/master/examples/vote/rust/vote.rs) to see what the code looks like in Rust. This will help you better understand Rust syntax and Solana’s design principles.
+Poseidon helps by transpiling your TypeScript program into Rust using the Anchor framework format. You can check out [examples/vote/rust/vote.rs](../../examples/vote/rust/vote.rs) to see what the code looks like in Rust. This will help you better understand Rust syntax and Solana’s design principles.
 
 After finishing this tutorial, we highly recommend going through all the resources in the reference section one-by-one. This will give you a more comprehensive understanding of how Solana works and help clarify some common jargon, such as account, PDA, rent, and more.
 


### PR DESCRIPTION
This PR fixes broken links to the examples directory and the tutorial. Changes them from absolute links to relative links (ensures it works even in forked repos).