### PR TITLE
feat: subcommands for compile and init

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1341,6 +1341,7 @@ dependencies = [
  "convert_case",
  "proc-macro2",
  "quote",
+ "regex",
  "rust-format",
  "swc_common",
  "swc_ecma_ast",
@@ -1517,9 +1518,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.10.2"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "380b951a9c5e80ddfd6136919eef32310721aa4aacd4889a8d39124b026ab343"
+checksum = "38200e5ee88914975b69f657f0801b6f6dccafd44fd9326302a4aaeecfacb1d8"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -1529,9 +1530,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.3"
+version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f804c7828047e88b2d32e2d7fe5a105da8ee3264f01902f796c8e067dc2483f"
+checksum = "368758f23274712b504848e9d5a6f010445cc8b87a7cdb4d7cbee666c1288da3"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -1540,9 +1541,9 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.8.2"
+version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c08c74e62047bb2de4ff487b251e4a92e24f48745648451635cec7d591162d9f"
+checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
 
 [[package]]
 name = "rust-format"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,3 +15,4 @@ proc-macro2 = "1.0.69"
 rust-format = { version = "0.3.4", features = ["pretty_please"] }
 anchor-lang = { version = "0.30.0", features = ["init-if-needed"]}
 clap = { version = "4.4.8", features = ["derive", "cargo"] }
+regex = "1.11.0"

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -5,9 +5,12 @@ use std::{
     process::{Command, Stdio},
 };
 
+use convert_case::{Case, Casing};
 use regex::Regex;
 
 pub fn init(name: &String) {
+    println!("Initializing project: {}", name);
+
     if !anchor_installed() {
         println!("Anchor CLI not installed. Please install it before running this command.");
         return;
@@ -55,6 +58,27 @@ pub fn init(name: &String) {
             ts_programs_src_path
         )
     });
+
+    let program_file_name = name.to_case(Case::Camel);
+
+    // Create the ts-programs src/{programName}.ts file and add default content
+    let ts_programs_src_program_path =
+        ts_programs_src_path.join(format!("{}.ts", program_file_name));
+    fs::write(
+        &ts_programs_src_program_path,
+        get_default_program_content(&name),
+    )
+    .unwrap_or_else(|_| {
+        panic!(
+            "Failed to create {} file at {:?}",
+            program_file_name, ts_programs_src_program_path
+        )
+    });
+
+    println!(
+        "\n\nSetup successful!\n\nChange to your directory and start developing:\ncd {}",
+        name
+    );
 }
 
 fn anchor_installed() -> bool {
@@ -83,4 +107,19 @@ fn execute_cmd(cmd: &mut Command) {
     for line in lines {
         println!("{}", line.unwrap());
     }
+}
+
+fn get_default_program_content(program_name: &str) -> String {
+    format!(
+        r#"import {{ Pubkey, Result }} from "@solanaturbine/poseidon";
+
+export default class {} {{
+    static PROGRAM_ID = new Pubkey("11111111111111111111111111111111");
+
+    initialize(): Result {{
+        // Write your program here
+    }}
+}}"#,
+        program_name.to_case(Case::Pascal)
+    )
 }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -111,7 +111,7 @@ fn execute_cmd(cmd: &mut Command) {
 
 fn get_default_program_content(program_name: &str) -> String {
     format!(
-        r#"import {{ Pubkey, Result }} from "@solanaturbine/poseidon";
+        r#"import {{ Pubkey, type Result }} from "@solanaturbine/poseidon";
 
 export default class {} {{
     static PROGRAM_ID = new Pubkey("11111111111111111111111111111111");

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,0 +1,86 @@
+use std::{
+    env, fs,
+    io::{BufRead, BufReader},
+    path::Path,
+    process::{Command, Stdio},
+};
+
+use regex::Regex;
+
+pub fn init(name: &String) {
+    if !anchor_installed() {
+        println!("Anchor CLI not installed. Please install it before running this command.");
+        return;
+    }
+
+    if !is_valid_project_name(&name) {
+        println!("Invalid project name. Project names must start with a letter and contain only alphanumeric characters and hyphens.");
+        return;
+    }
+
+    execute_cmd(Command::new("anchor").args(["init", name.as_str()]));
+
+    let project_path = Path::new(&name);
+
+    // Create the ts-programs directory
+    let ts_programs_path = project_path.join("ts-programs");
+    fs::create_dir(&ts_programs_path).unwrap_or_else(|_| {
+        panic!(
+            "Failed to create ts-programs directory at {:?}",
+            ts_programs_path
+        )
+    });
+
+    let original_dir =
+        env::current_dir().unwrap_or_else(|_| panic!("Failed to get current directory"));
+
+    env::set_current_dir(&ts_programs_path).unwrap_or_else(|_| {
+        panic!(
+            "Failed to change directory to: {}",
+            project_path.join(ts_programs_path.clone()).display()
+        )
+    });
+
+    execute_cmd(Command::new("npm").args(["init", "-y"]));
+
+    execute_cmd(Command::new("npm").args(["add", "@solanaturbine/poseidon"]));
+
+    env::set_current_dir(original_dir).expect("Failed to change directory back to original");
+
+    // Create the ts-programs src directory
+    let ts_programs_src_path = ts_programs_path.join("src");
+    fs::create_dir(&ts_programs_src_path).unwrap_or_else(|_| {
+        panic!(
+            "Failed to create ts-programs src directory at {:?}",
+            ts_programs_src_path
+        )
+    });
+}
+
+fn anchor_installed() -> bool {
+    Command::new("anchor")
+        .arg("--version")
+        .output()
+        .map_or(false, |output| output.status.success())
+}
+
+fn is_valid_project_name(name: &str) -> bool {
+    let re = Regex::new(r"^[a-zA-Z][a-zA-Z0-9\-]*$").unwrap();
+    re.is_match(name)
+}
+
+/// Executes a command and streams the output to stdout.
+fn execute_cmd(cmd: &mut Command) {
+    let mut child = cmd
+        .stdout(Stdio::piped())
+        .spawn()
+        .expect("Failed to execute command");
+
+    let stdout = child.stdout.take().unwrap();
+
+    // Stream output.
+    let lines = BufReader::new(stdout).lines();
+    for line in lines {
+        println!("{}", line.unwrap());
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,31 +1,57 @@
-use std::path::Path;
-mod rs_types;
-mod ts_types;
+mod cli;
 mod errors;
-mod transpiler;
 mod parse_ts;
-use clap::{Parser as ClapParser, Subcommand};
+mod rs_types;
+mod transpiler;
+mod ts_types;
 
 use anyhow::Result;
-
-use swc_ecma_ast::Module;
-use transpiler::transpile;
+use clap::{Parser as ClapParser, Subcommand};
 use parse_ts::parse_ts;
+use swc_ecma_ast::Module;
+
+use cli::init;
+use transpiler::transpile;
 
 #[derive(ClapParser, Debug)]
 #[command(author, version, about, long_about = None)]
+#[command(propagate_version = true)]
 struct Cli {
-    #[arg(short, long, help = "Input Typescript file")]
-    input: String,
+    #[command(subcommand)]
+    command: Commands,
+}
 
-    #[arg(short, long, help = "Output Rust file")]
-    output: String,
+#[derive(Subcommand, Debug)]
+enum Commands {
+    /// Transpile a Typescript program to a Rust program
+    Compile {
+        /// Input Typescript file path
+        #[arg(short, long, help = "Input Typescript file")]
+        input: String,
+        /// Output Rust file path
+        #[arg(short, long, help = "Output Rust file")]
+        output: String,
+    },
+    /// Initializes a new workspace
+    Init {
+        /// Workspace name
+        name: String,
+    },
 }
 
 fn main() -> Result<()> {
     let cli = Cli::parse();
 
-    let module: Module = parse_ts(cli.input);
-    transpile(&module, cli.output)?;
+    match &cli.command {
+        Commands::Compile { input, output } => {
+            let module: Module = parse_ts(input);
+            transpile(&module, output)?;
+        }
+        Commands::Init { name } => {
+            println!("Initializing project: {}", name);
+            init(name);
+        }
+    }
+
     Ok(())
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -48,7 +48,6 @@ fn main() -> Result<()> {
             transpile(&module, output)?;
         }
         Commands::Init { name } => {
-            println!("Initializing project: {}", name);
             init(name);
         }
     }

--- a/src/parse_ts.rs
+++ b/src/parse_ts.rs
@@ -8,7 +8,7 @@ use swc_common::{
 use swc_ecma_ast::Module;
 use swc_ecma_parser::{lexer::Lexer, Capturing, Parser, StringInput, Syntax};
 
-pub fn parse_ts(input_file_name: String) -> Module {
+pub fn parse_ts(input_file_name: &String) -> Module {
     let cm: Lrc<SourceMap> = Default::default();
     let handler = Handler::with_tty_emitter(ColorConfig::Auto, true, false, Some(cm.clone()));
 

--- a/src/transpiler.rs
+++ b/src/transpiler.rs
@@ -6,7 +6,7 @@ use crate::rs_types::{ProgramAccount, ProgramModule};
 use anyhow::Result;
 use swc_ecma_ast::*;
 
-pub fn transpile(module: &Module, output_file_name: String) -> Result<()> {
+pub fn transpile(module: &Module, output_file_name: &String) -> Result<()> {
     let mut imports = vec![];
     let mut accounts: HashMap<String, ProgramAccount> = HashMap::new();
     let mut program_class: Option<ClassExpr> = None;


### PR DESCRIPTION
- Moved `input` and `output` flags to CLI subcommand `compile`
- Added `init` subcommand which wraps over `anchor init`, and initializes `ts-programs/src/programName.ts` with default content