### PR TITLE
Fixes for string and array data types

### DIFF
--- a/src/errors.rs
+++ b/src/errors.rs
@@ -17,4 +17,12 @@ pub enum PoseidonError {
     ArrayNotFound,
     #[error("expected a Call type")]
     CallNotFound,
+    #[error("expected a type reference")]
+    TypeReferenceNotFound,
+    #[error("expected a TS literal type")]
+    TSLiteralTypeNotFound,
+    #[error("expected a numeric literal for TS literal type")]
+    NumericLiteralNotFound,
+    #[error("expected a Atom type")]
+    AtomNotFound,
 }

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -5,6 +5,8 @@ use thiserror::*;
 pub enum PoseidonError {
     #[error("Invalid type: {0}")]
     InvalidType(String),
+    #[error("Keyword type {0} is not supported")]
+    KeyWordTypeNotSupported(String),
     #[error("expected a Member type")]
     MemberNotFound,
     #[error("expected a Expr type")]

--- a/src/rs_types.rs
+++ b/src/rs_types.rs
@@ -410,7 +410,6 @@ impl ProgramInstruction {
             .ok_or(PoseidonError::IdentNotFound)?
             .sym
             .to_string();
-        // println!("{}",name);
         let mut ix: ProgramInstruction = ProgramInstruction::new(name);
         // Get accounts and args
         let mut ix_accounts: HashMap<String, InstructionAccount> = HashMap::new();
@@ -545,7 +544,6 @@ impl ProgramInstruction {
             ?.stmts
             .iter()
             .map(|s| {
-                // println!("start : {:#?}", s);
                 match s.clone() {
                     Stmt::Expr(e) => {
                         let s = e.expr;
@@ -1352,7 +1350,7 @@ impl ProgramAccount {
                 if field_type.contains("Vec") | field_type.contains("String") {
                     space += 4;
 
-                    println!("\nEnter the length for {}", field_type);
+                    println!(r##"Enter the length for "{}" of type "{}" in "{}" interface"##, field_name, field_type, name);
                     let mut user_input_len = String::new();
                     io::stdin()
                         .read_line(&mut user_input_len)
@@ -1361,6 +1359,7 @@ impl ProgramAccount {
                         .trim()
                         .parse::<u32>()
                         .expect("input a valid number in u32 range");
+                    println!();
                 }
 
                 if field_type.contains("Pubkey") {

--- a/src/rs_types.rs
+++ b/src/rs_types.rs
@@ -1350,6 +1350,8 @@ impl ProgramAccount {
                 if field_type.contains("Vec") | field_type.contains("String") {
                     space += 4;
 
+                    println!();
+                    println!("Anchor space reference: - https://www.anchor-lang.com/docs/space");
                     println!(r##"Enter the length for "{}" of type "{}" in "{}" interface"##, field_name, field_type, name);
                     let mut user_input_len = String::new();
                     io::stdin()
@@ -1360,6 +1362,19 @@ impl ProgramAccount {
                         .parse::<u32>()
                         .expect("input a valid number in u32 range");
                     println!();
+
+                    if field_type.contains("Vec<String>") {
+                        println!(r##"Enter the average length for values in "{}" of type "{}" in "{}" interface"##, field_name, field_type, name);
+                        let mut average_string_len = String::new();
+                        io::stdin()
+                            .read_line(&mut average_string_len)
+                            .expect("enter only a number");
+                        len *= average_string_len
+                            .trim()
+                            .parse::<u32>()
+                            .expect("input a valid number in u32 range");
+                        println!();
+                    }
                 }
 
                 if field_type.contains("Pubkey") {

--- a/src/rs_types.rs
+++ b/src/rs_types.rs
@@ -15,7 +15,7 @@ use swc_ecma_parser::token::Token;
 
 use crate::{
     errors::PoseidonError,
-    ts_types::{rs_type_from_str, struct_rs_type_from_str, STANDARD_ACCOUNT_TYPES, STANDARD_ARRAY_TYPES, STANDARD_TYPES},
+    ts_types::{rs_type_from_str, STANDARD_ACCOUNT_TYPES, STANDARD_ARRAY_TYPES, STANDARD_TYPES},
 };
 use anyhow::{anyhow, Error, Ok, Result};
 
@@ -419,15 +419,18 @@ impl ProgramInstruction {
             let name = id.sym.to_string();
             let snaked_name = id.sym.to_string().to_case(Case::Snake);
             let binding = type_ann.expect("Invalid type annotation");
-            let (of_type, optional) = extract_of_type(binding)
+            let (of_type, optional) = extract_type(binding)
                 .unwrap_or_else(|_| panic!("Keyword type is not supported"));
 
             // TODO: Make this an actual Enum set handle it correctly
             if STANDARD_TYPES.contains(&of_type.as_str()) | STANDARD_ARRAY_TYPES.contains(&of_type.as_str()) {
+                let rs_type = rs_type_from_str(&of_type)
+                        .unwrap_or_else(|_| panic!("Invalid type: {}", of_type));
                 ix_arguments.push(InstructionArgument {
                     name: snaked_name,
-                    of_type: rs_type_from_str(&of_type)
-                        .unwrap_or_else(|_| panic!("Invalid type: {}", of_type)),
+                    of_type: quote!(
+                        #rs_type, 
+                    ),
                     optional,
                 })
             } else if STANDARD_ACCOUNT_TYPES.contains(&of_type.as_str()) {
@@ -1275,14 +1278,14 @@ impl ProgramInstruction {
     }
 }
 
-fn extract_kind_str(keyword_type: TsKeywordTypeKind) -> Result<String, Error> {
-    match keyword_type {
-        TsKeywordTypeKind::TsStringKeyword => Ok("String".to_string()),
-        _ => Err(PoseidonError::KeyWordTypeNotSupported(format!("{:?}", keyword_type)).into()),
-    }
-}
+// fn extract_kind_str(keyword_type: TsKeywordTypeKind) -> Result<String, Error> {
+//     match keyword_type {
+//         TsKeywordTypeKind::TsStringKeyword => Ok("String".to_string()),
+//         _ => Err(PoseidonError::KeyWordTypeNotSupported(format!("{:?}", keyword_type)).into()),
+//     }
+// }
 
-fn extract_of_type(binding: Box<swc_ecma_ast::TsTypeAnn>) -> Result<(String, bool), Error> {
+fn extract_type(binding: Box<swc_ecma_ast::TsTypeAnn>) -> Result<(String, bool), Error> {
     match binding.type_ann.as_ref() {
         TsType::TsTypeRef(_) => {
             let ident = binding
@@ -1294,29 +1297,29 @@ fn extract_of_type(binding: Box<swc_ecma_ast::TsTypeAnn>) -> Result<(String, boo
             Ok((ident.sym.to_string(), ident.optional))
         }
         TsType::TsArrayType(_) => {
-            let keyword_type = binding
+            let array_elem_type = binding
                 .type_ann
                 .expect_ts_array_type()
                 .elem_type
-                .expect_ts_keyword_type()
-                .kind;
+                .expect_ts_type_ref()
+                .type_name
+                .expect_ident()
+                .sym
+                .to_string();
 
-            let kind_type = extract_kind_str(keyword_type)
-                .unwrap_or_else(|_| panic!("Keyword type {:?} is not supported", keyword_type));
-
-            Ok((format!("Vec<{}>", kind_type), false))
+            Ok((format!("Vec<{}>", array_elem_type), false))
         }
-        TsType::TsKeywordType(_) => {
-            let keyword_type = binding
-                .type_ann
-                .expect_ts_keyword_type()
-                .kind;
+        // TsType::TsKeywordType(_) => {
+        //     let keyword_type = binding
+        //         .type_ann
+        //         .expect_ts_keyword_type()
+        //         .kind;
 
-            let kind_type = extract_kind_str(keyword_type)
-                .unwrap_or_else(|_| panic!("Keyword type {:?} is not supported", keyword_type));
+        //     let kind_type = extract_kind_str(keyword_type)
+        //         .unwrap_or_else(|_| panic!("Keyword type {:?} is not supported", keyword_type));
 
-            Ok((kind_type, false))
-        }
+        //     Ok((kind_type, false))
+        // }
         _ => Err(PoseidonError::KeyWordTypeNotSupported(format!("{:?}", binding.type_ann.as_ref())).into()),
     }
 }
@@ -1352,7 +1355,7 @@ impl ProgramAccount {
                 let field = f.clone().ts_property_signature().expect("Invalid property");
                 let field_name = field.key.ident().expect("Invalid property").sym.to_string();
                 let binding = field.type_ann.expect("Invalid type annotation");
-                let (field_type, _optional) = extract_of_type(binding)
+                let (field_type, _optional) = extract_type(binding)
                     .unwrap_or_else(|_| panic!("Keyword type is not supported"));
 
                 // TODO:: space of other types e.g string or move to macro InitSpace
@@ -1399,7 +1402,7 @@ impl ProgramAccount {
                     proc_macro2::Span::call_site(),
                 );
 
-                let field_type = struct_rs_type_from_str(&field.of_type)
+                let field_type = rs_type_from_str(&field.of_type)
                         .unwrap_or_else(|_| panic!("Invalid type: {}", field.of_type));
 
                 quote! { pub #field_name: #field_type }

--- a/src/rs_types.rs
+++ b/src/rs_types.rs
@@ -11,10 +11,12 @@ use std::{
 use swc_common::{util::move_map::MoveMap, TypeEq};
 use swc_ecma_ast::{
     BindingIdent, CallExpr, Callee, ClassExpr, ClassMethod, Expr, ExprOrSpread, Lit, MemberExpr,
-    NewExpr, Stmt, TsExprWithTypeArgs, TsInterfaceDecl, TsKeywordTypeKind, TsType, TsTypeRef,
+    NewExpr, Stmt, TsExprWithTypeArgs, TsInterfaceDecl, TsKeywordTypeKind, TsType,
+    TsTypeParamInstantiation, TsTypeRef,
 };
 use swc_ecma_parser::token::Token;
 
+use crate::ts_types;
 use crate::{
     errors::PoseidonError,
     ts_types::{rs_type_from_str, STANDARD_ACCOUNT_TYPES, STANDARD_ARRAY_TYPES, STANDARD_TYPES},
@@ -420,7 +422,7 @@ impl ProgramInstruction {
             let name = id.sym.to_string();
             let snaked_name = id.sym.to_string().to_case(Case::Snake);
             let binding = type_ann.expect("Invalid type annotation");
-            let (of_type, optional) =
+            let (of_type, _len, optional) =
                 extract_type(binding).unwrap_or_else(|_| panic!("Keyword type is not supported"));
 
             if STANDARD_TYPES.contains(&of_type.as_str())
@@ -1279,29 +1281,33 @@ impl ProgramInstruction {
     }
 }
 
-fn extract_type(binding: Box<swc_ecma_ast::TsTypeAnn>) -> Result<(String, bool), Error> {
+fn extract_type(binding: Box<swc_ecma_ast::TsTypeAnn>) -> Result<(String, u32, bool), Error> {
+    let ts_type: String;
+    let length: u32;
     match binding.type_ann.as_ref() {
         TsType::TsTypeRef(_) => {
             let ident = binding
                 .type_ann
-                .expect_ts_type_ref()
+                .as_ts_type_ref()
+                .ok_or(PoseidonError::TypeReferenceNotFound)?
                 .type_name
-                .expect_ident();
+                .as_ident()
+                .ok_or(PoseidonError::IdentNotFound)?;
 
-            Ok((ident.sym.to_string(), ident.optional))
-        }
-        TsType::TsArrayType(_) => {
-            let array_elem_type = binding
+            if let Some(type_params) = &binding
                 .type_ann
-                .expect_ts_array_type()
-                .elem_type
-                .expect_ts_type_ref()
-                .type_name
-                .expect_ident()
-                .sym
-                .to_string();
+                .as_ts_type_ref()
+                .ok_or(PoseidonError::TypeReferenceNotFound)?
+                .type_params
+            {
+                (ts_type, length) =
+                    extract_name_and_len_with_type_params(ident.sym.as_ref(), type_params)?;
+            } else {
+                ts_type = String::from(ident.sym.to_string());
+                length = 1;
+            }
 
-            Ok((format!("Vec<{}>", array_elem_type), false))
+            Ok((ts_type, length, ident.optional))
         }
         _ => Err(PoseidonError::KeyWordTypeNotSupported(format!(
             "{:?}",
@@ -1309,6 +1315,55 @@ fn extract_type(binding: Box<swc_ecma_ast::TsTypeAnn>) -> Result<(String, bool),
         ))
         .into()),
     }
+}
+
+pub fn extract_name_and_len_with_type_params(
+    primary_type_ident: &str,
+    type_params: &Box<TsTypeParamInstantiation>,
+) -> Result<(String, u32), Error> {
+    let ts_type: String;
+    let mut length: u32 = 0;
+    match primary_type_ident {
+        "String" => {
+            length += type_params.params[0]
+                .as_ts_lit_type()
+                .ok_or(PoseidonError::TSLiteralTypeNotFound)?
+                .lit
+                .as_number()
+                .ok_or(PoseidonError::NumericLiteralNotFound)?
+                .value as u32;
+            ts_type = String::from("String");
+        }
+        "Vec" => {
+            let vec_type_name = type_params.params[0]
+                .as_ts_type_ref()
+                .ok_or(PoseidonError::TypeReferenceNotFound)?
+                .type_name
+                .as_ident()
+                .ok_or(PoseidonError::IdentNotFound)?
+                .sym
+                .to_string();
+
+            let vec_len = type_params.params[1]
+                .as_ts_lit_type()
+                .ok_or(PoseidonError::TSLiteralTypeNotFound)?
+                .lit
+                .as_number()
+                .ok_or(PoseidonError::NumericLiteralNotFound)?
+                .value as u32;
+
+            ts_type = format!("Vec<{}>", vec_type_name);
+
+            length += vec_len;
+        }
+        _ => {
+            return Err(
+                PoseidonError::KeyWordTypeNotSupported(format!("{:?}", primary_type_ident)).into(),
+            )
+        }
+    }
+
+    Ok((ts_type, length))
 }
 
 #[derive(Debug, Clone)]
@@ -1342,39 +1397,11 @@ impl ProgramAccount {
                 let field = f.clone().ts_property_signature().expect("Invalid property");
                 let field_name = field.key.ident().expect("Invalid property").sym.to_string();
                 let binding = field.type_ann.expect("Invalid type annotation");
-                let (field_type, _optional) = extract_type(binding)
+                let (field_type, len, _optional) = extract_type(binding)
                     .unwrap_or_else(|_| panic!("Keyword type is not supported"));
-
-                let mut len: u32 = 1;
 
                 if field_type.contains("Vec") | field_type.contains("String") {
                     space += 4;
-
-                    println!();
-                    println!("Anchor space reference: - https://www.anchor-lang.com/docs/space");
-                    println!(r##"Enter the length for "{}" of type "{}" in "{}" interface"##, field_name, field_type, name);
-                    let mut user_input_len = String::new();
-                    io::stdin()
-                        .read_line(&mut user_input_len)
-                        .expect("enter only a number");
-                    len = user_input_len
-                        .trim()
-                        .parse::<u32>()
-                        .expect("input a valid number in u32 range");
-                    println!();
-
-                    if field_type.contains("Vec<String>") {
-                        println!(r##"Enter the average length for values in "{}" of type "{}" in "{}" interface"##, field_name, field_type, name);
-                        let mut average_string_len = String::new();
-                        io::stdin()
-                            .read_line(&mut average_string_len)
-                            .expect("enter only a number");
-                        len *= average_string_len
-                            .trim()
-                            .parse::<u32>()
-                            .expect("input a valid number in u32 range");
-                        println!();
-                    }
                 }
 
                 if field_type.contains("Pubkey") {
@@ -1388,6 +1415,8 @@ impl ProgramAccount {
                 } else if field_type.contains("u8") | field_type.contains("i8") {
                     space += 1 * len;
                 } else if field_type.contains("String") {
+                    space += len;
+                } else if field_type.contains("Boolean") {
                     space += len;
                 }
 

--- a/src/ts_types.rs
+++ b/src/ts_types.rs
@@ -2,7 +2,7 @@ use anyhow::{Error, Result};
 use proc_macro2::TokenStream;
 use quote::quote;
 
-pub const STANDARD_TYPES: [&str; 17] = [
+pub const STANDARD_TYPES: [&str; 16] = [
     "u8",
     "i8",
     "u16",
@@ -17,12 +17,11 @@ pub const STANDARD_TYPES: [&str; 17] = [
     "isize",
     "boolean",
     "Uint8Array",
-    "string",
     "String",
     "Pubkey",
 ];
 
-pub const STANDARD_ARRAY_TYPES: [&str; 2] = ["Vec<string>", "Vec<String>"];
+pub const STANDARD_ARRAY_TYPES: [&str; 1] = ["Vec<String>"];
 
 pub const STANDARD_ACCOUNT_TYPES: [&str; 7] = [
     "Signer",
@@ -60,32 +59,9 @@ use crate::errors::PoseidonError;
 //         _ => str.to_string()
 //     }
 // }
+
+
 pub fn rs_type_from_str(str: &str) -> Result<TokenStream, Error> {
-    match str {
-        "string" | "String" => Ok(quote! { String, }),
-        "Vec<string>" | "Vec<String>" => Ok(quote! { Vec<String>, }),
-        "u8" => Ok(quote! { u8, }),
-        "i8" => Ok(quote! { i8, }),
-        "u16" => Ok(quote! { u16, }),
-        "i16" => Ok(quote! { i16, }),
-        "u32" => Ok(quote! { u32, }),
-        "i32" => Ok(quote! { i32, }),
-        "u64" => Ok(quote! { u64, }),
-        "i64" => Ok(quote! { i64, }),
-        "u128" => Ok(quote! { u128, }),
-        "i128" => Ok(quote! { i128, }),
-        "usize" => Ok(quote! { usize, }),
-        "isize" => Ok(quote! { isize, }),
-        "boolean" => Ok(quote! { bool, }),
-        "Pubkey" => Ok(quote! { Pubkey, }),
-        "Uint8Array" => Ok(quote! { Vec<u8>, }),
-        // "Signer" => Ok(quote!{Signer}),
-        _ => Err(PoseidonError::InvalidType(str.to_string()))?,
-    }
-}
-
-
-pub fn struct_rs_type_from_str(str: &str) -> Result<TokenStream, Error> {
     match str {
         "string" | "String" => Ok(quote! { String }),
         "Vec<string>" | "Vec<String>" => Ok(quote! { Vec<String> }),

--- a/src/ts_types.rs
+++ b/src/ts_types.rs
@@ -22,6 +22,8 @@ pub const STANDARD_TYPES: [&str; 17] = [
     "Pubkey",
 ];
 
+pub const STANDARD_ARRAY_TYPES: [&str; 2] = ["Vec<string>", "Vec<String>"];
+
 pub const STANDARD_ACCOUNT_TYPES: [&str; 7] = [
     "Signer",
     "UncheckedAccount",
@@ -60,7 +62,8 @@ use crate::errors::PoseidonError;
 // }
 pub fn rs_type_from_str(str: &str) -> Result<TokenStream, Error> {
     match str {
-        "string" | "String" => Ok(quote! { String }),
+        "string" | "String" => Ok(quote! { String, }),
+        "Vec<string>" | "Vec<String>" => Ok(quote! { Vec<String>, }),
         "u8" => Ok(quote! { u8, }),
         "i8" => Ok(quote! { i8, }),
         "u16" => Ok(quote! { u16, }),
@@ -76,6 +79,31 @@ pub fn rs_type_from_str(str: &str) -> Result<TokenStream, Error> {
         "boolean" => Ok(quote! { bool, }),
         "Pubkey" => Ok(quote! { Pubkey, }),
         "Uint8Array" => Ok(quote! { Vec<u8>, }),
+        // "Signer" => Ok(quote!{Signer}),
+        _ => Err(PoseidonError::InvalidType(str.to_string()))?,
+    }
+}
+
+
+pub fn struct_rs_type_from_str(str: &str) -> Result<TokenStream, Error> {
+    match str {
+        "string" | "String" => Ok(quote! { String }),
+        "Vec<string>" | "Vec<String>" => Ok(quote! { Vec<String> }),
+        "u8" => Ok(quote! { u8 }),
+        "i8" => Ok(quote! { i8 }),
+        "u16" => Ok(quote! { u16 }),
+        "i16" => Ok(quote! { i16 }),
+        "u32" => Ok(quote! { u32 }),
+        "i32" => Ok(quote! { i32 }),
+        "u64" => Ok(quote! { u64 }),
+        "i64" => Ok(quote! { i64 }),
+        "u128" => Ok(quote! { u128 }),
+        "i128" => Ok(quote! { i128 }),
+        "usize" => Ok(quote! { usize }),
+        "isize" => Ok(quote! { isize }),
+        "boolean" => Ok(quote! { bool }),
+        "Pubkey" => Ok(quote! { Pubkey }),
+        "Uint8Array" => Ok(quote! { Vec<u8> }),
         // "Signer" => Ok(quote!{Signer}),
         _ => Err(PoseidonError::InvalidType(str.to_string()))?,
     }

--- a/src/ts_types.rs
+++ b/src/ts_types.rs
@@ -15,7 +15,7 @@ pub const STANDARD_TYPES: [&str; 16] = [
     "i128",
     "usize",
     "isize",
-    "boolean",
+    "Boolean",
     "Uint8Array",
     "String",
     "Pubkey",
@@ -34,7 +34,7 @@ pub const STANDARD_ARRAY_TYPES: [&str; 13] = [
     "Vec<u128>",
     "Vec<i128>",
     "Vec<Pubkey>",
-    "Vec<boolean>",
+    "Vec<Boolean>",
 ];
 
 pub const STANDARD_ACCOUNT_TYPES: [&str; 7] = [
@@ -64,7 +64,7 @@ pub fn rs_type_from_str(str: &str) -> Result<TokenStream, Error> {
         "Vec<u128>" => Ok(quote! { Vec<u128> }),
         "Vec<i128>" => Ok(quote! { Vec<i128> }),
         "Vec<Pubkey>" => Ok(quote! { Vec<Pubkey> }),
-        "Vec<boolean>" => Ok(quote! { Vec<bool> }),
+        "Vec<Boolean>" => Ok(quote! { Vec<bool> }),
         "u8" => Ok(quote! { u8 }),
         "i8" => Ok(quote! { i8 }),
         "u16" => Ok(quote! { u16 }),
@@ -77,7 +77,7 @@ pub fn rs_type_from_str(str: &str) -> Result<TokenStream, Error> {
         "i128" => Ok(quote! { i128 }),
         "usize" => Ok(quote! { usize }),
         "isize" => Ok(quote! { isize }),
-        "boolean" => Ok(quote! { bool }),
+        "Boolean" => Ok(quote! { bool }),
         "Pubkey" => Ok(quote! { Pubkey }),
         "Uint8Array" => Ok(quote! { Vec<u8> }),
         // "Signer" => Ok(quote!{Signer}),

--- a/src/ts_types.rs
+++ b/src/ts_types.rs
@@ -21,7 +21,7 @@ pub const STANDARD_TYPES: [&str; 16] = [
     "Pubkey",
 ];
 
-pub const STANDARD_ARRAY_TYPES: [&str; 1] = ["Vec<String>"];
+pub const STANDARD_ARRAY_TYPES: [&str; 13] = ["Vec<String>", "Vec<u8>", "Vec<i8>", "Vec<u16>", "Vec<i16>", "Vec<u32>", "Vec<i32>", "Vec<u64>", "Vec<i64>", "Vec<u128>", "Vec<i128>", "Vec<Pubkey>", "Vec<boolean>"];
 
 pub const STANDARD_ACCOUNT_TYPES: [&str; 7] = [
     "Signer",
@@ -63,8 +63,20 @@ use crate::errors::PoseidonError;
 
 pub fn rs_type_from_str(str: &str) -> Result<TokenStream, Error> {
     match str {
-        "string" | "String" => Ok(quote! { String }),
-        "Vec<string>" | "Vec<String>" => Ok(quote! { Vec<String> }),
+        "String" => Ok(quote! { String }),
+        "Vec<String>" => Ok(quote! { Vec<String> }),
+        "Vec<u8>" => Ok(quote! { Vec<u8> }),
+        "Vec<i8>" => Ok(quote! { Vec<i8> }),
+        "Vec<u16>" => Ok(quote! { Vec<u16> }),
+        "Vec<i16>" => Ok(quote! { Vec<i16> }),
+        "Vec<u32>" => Ok(quote! { Vec<u32> }),
+        "Vec<i32>" => Ok(quote! { Vec<i32> }),
+        "Vec<u64>" => Ok(quote! { Vec<u64> }),
+        "Vec<i64>" => Ok(quote! { Vec<i64> }),
+        "Vec<u128>" => Ok(quote! { Vec<u128> }),
+        "Vec<i128>" => Ok(quote! { Vec<i128> }),
+        "Vec<Pubkey>" => Ok(quote! { Vec<Pubkey> }),
+        "Vec<boolean>" => Ok(quote! { Vec<bool> }),
         "u8" => Ok(quote! { u8 }),
         "i8" => Ok(quote! { i8 }),
         "u16" => Ok(quote! { u16 }),

--- a/src/ts_types.rs
+++ b/src/ts_types.rs
@@ -21,7 +21,21 @@ pub const STANDARD_TYPES: [&str; 16] = [
     "Pubkey",
 ];
 
-pub const STANDARD_ARRAY_TYPES: [&str; 13] = ["Vec<String>", "Vec<u8>", "Vec<i8>", "Vec<u16>", "Vec<i16>", "Vec<u32>", "Vec<i32>", "Vec<u64>", "Vec<i64>", "Vec<u128>", "Vec<i128>", "Vec<Pubkey>", "Vec<boolean>"];
+pub const STANDARD_ARRAY_TYPES: [&str; 13] = [
+    "Vec<String>",
+    "Vec<u8>",
+    "Vec<i8>",
+    "Vec<u16>",
+    "Vec<i16>",
+    "Vec<u32>",
+    "Vec<i32>",
+    "Vec<u64>",
+    "Vec<i64>",
+    "Vec<u128>",
+    "Vec<i128>",
+    "Vec<Pubkey>",
+    "Vec<boolean>",
+];
 
 pub const STANDARD_ACCOUNT_TYPES: [&str; 7] = [
     "Signer",
@@ -34,32 +48,6 @@ pub const STANDARD_ACCOUNT_TYPES: [&str; 7] = [
 ];
 
 use crate::errors::PoseidonError;
-// pub enum StandardTypes {
-//     U8(u8),
-//     I8(i8),
-//     U16(u16),
-//     I16(i16),
-//     U32(u32),
-//     I32(i32),
-//     U64(u64),
-//     I64(i64),
-//     U128(u128),
-//     I128(i128),
-//     USize(usize),
-//     ISize(isize),
-//     Bool(bool),
-//     VecU8(Vec<u8>),
-//     String(String),
-// }
-// pub fn rs_type_from_str(str: &str) -> String {
-//     match str {
-//         "Uint8Array" => "Vec<u8>".to_string(),
-//         "boolean" => "bool".to_string(),
-//         "string" => "String".to_string(),
-//         _ => str.to_string()
-//     }
-// }
-
 
 pub fn rs_type_from_str(str: &str) -> Result<TokenStream, Error> {
     match str {


### PR DESCRIPTION
Adds Support for string and array data types

- New function `struct_rs_type_from_str` in ts_types.rs to build rust token stream from string value
- For existing function `rs_type_from_str` add a comma punctuation to correct token stream for class params
- New function `extract_of_type` that matches type of typescript data types between TsTypeRef e.g u8, TsKeywordType e.g string and TsArrayType e.g string[]
- Simple conversion of TsArrayType string[] to Vec<String>
- In ts_types.rs a new array type for string arrays

Reference Code
- https://github.com/mwaa/program-examples/tree/add-basics-favorites-poseidon/basics/favorites/poseidon

Please note functionality
- Currently expects using `string[]` an improvement could be to support `Array<String>` which falls under TsTypeRef
- Space added a big value of 100 for other data types an improvement could be to use the macro InitSpace or explicit access on setting space value


Closes #10 
Closes #7