### PR TITLE
Refactor `failed to load` error message in parse_ts.rs

### DIFF
--- a/src/parse_ts.rs
+++ b/src/parse_ts.rs
@@ -15,15 +15,15 @@ pub fn parse_ts(input_file_name: &String) -> Module {
     // Real usage
     // let fm = cm
     //     .load_file(Path::new("counter.ts"))
-    //     .expect("failed to load test.ts");
+    //     .expect("failed to load counter.ts");
 
     // let fm = cm
     //     .load_file(Path::new("vault.ts"))
-    //     .expect("failed to load test.ts");
+    //     .expect("failed to load vault.ts");
 
     let fm = cm
         .load_file(Path::new(&input_file_name))
-        .expect("failed to load test.ts");
+        .expect(&format!("failed to load {}", input_file_name));
 
     let lexer = Lexer::new(
         Syntax::Typescript(Default::default()),

--- a/src/parse_ts.rs
+++ b/src/parse_ts.rs
@@ -12,15 +12,6 @@ pub fn parse_ts(input_file_name: &String) -> Module {
     let cm: Lrc<SourceMap> = Default::default();
     let handler = Handler::with_tty_emitter(ColorConfig::Auto, true, false, Some(cm.clone()));
 
-    // Real usage
-    // let fm = cm
-    //     .load_file(Path::new("counter.ts"))
-    //     .expect("failed to load counter.ts");
-
-    // let fm = cm
-    //     .load_file(Path::new("vault.ts"))
-    //     .expect("failed to load vault.ts");
-
     let fm = cm
         .load_file(Path::new(&input_file_name))
         .expect(&format!("failed to load {}", input_file_name));


### PR DESCRIPTION
### Description
This PR refines the error messages for loading files in `parse_ts.rs` by updating message strings for consistency and providing more contextual information. These changes include:

- Adjusting hardcoded file references to use dynamic file names, where appropriate.
- Updating outdated file names in error messages, making the context clearer.

### Changes
- `test.ts` error messages now replaced or made dynamic for accurate logging.
- Replaced hardcoded strings with `input_file_name` in `expect` messages for better context in error handling.

This refactoring improves the clarity of error logs, aiding in debugging and maintenance.

Fixes #23 