### PR TITLE
- Fixed missing imports and arguments

### DIFF
--- a/src/rs_types.rs
+++ b/src/rs_types.rs
@@ -487,6 +487,8 @@ impl ProgramInstruction {
                     ix.uses_token_program = true;
 
                     program_mod.add_import("anchor_spl", "associated_token", "AssociatedToken");
+                    program_mod.add_import("anchor_spl", "token", "TokenAccount");
+                    program_mod.add_import("anchor_spl", "token", "Token");
                 } else if of_type == "Mint" {
                     ix_accounts.insert(
                         name.clone(),
@@ -645,7 +647,7 @@ impl ProgramInstruction {
                                             cur_ix_acc.is_mut = true;
                                         }
                                         if cur_ix_acc.type_str != "AssociatedTokenAccount"{
-                                            let seeds = &derive_args[0].expr.as_array().ok_or(anyhow!("expected a array"))?.elems;
+                                            let seeds = &derive_args[0].expr.as_array().ok_or(anyhow!("expected an array"))?.elems;
                                             let seeds_token = ix.get_seeds(seeds)?;
                                             cur_ix_acc.bump = Some(quote!{
                                                 bump
@@ -792,6 +794,8 @@ impl ProgramInstruction {
                                         }
                                         },
                                         "burn" => {
+                                            program_mod.add_import("anchor_spl", "token", "burn");
+                                            program_mod.add_import("anchor_spl", "token", "Burn");
                                             let mint_acc = c.args[0].expr.as_ident().ok_or(PoseidonError::IdentNotFound)?.sym.as_ref();
                                             let from_acc = c.args[1].expr.as_ident().ok_or(PoseidonError::IdentNotFound)?.sym.as_ref();
                                             let auth_acc = c.args[2].expr.as_ident().ok_or(PoseidonError::IdentNotFound)?.sym.as_ref();
@@ -815,6 +819,8 @@ impl ProgramInstruction {
                                             })
                                         },
                                         "mintTo" => {
+                                            program_mod.add_import("anchor_spl", "token", "mint_to");
+                                            program_mod.add_import("anchor_spl", "token", "MintTo");
                                             let mint_acc = c.args[0].expr.as_ident().ok_or(PoseidonError::IdentNotFound)?.sym.as_ref();
                                             let to_acc = c.args[1].expr.as_ident().ok_or(PoseidonError::IdentNotFound)?.sym.as_ref();
                                             let auth_acc = c.args[2].expr.as_ident().ok_or(PoseidonError::IdentNotFound)?.sym.as_ref();
@@ -837,6 +843,8 @@ impl ProgramInstruction {
                                             })
                                         },
                                         "approve" => {
+                                            program_mod.add_import("anchor_spl", "token", "approve");
+                                            program_mod.add_import("anchor_spl", "token", "Approve");
                                             let to_acc = c.args[0].expr.as_ident().ok_or(PoseidonError::IdentNotFound)?.sym.as_ref();
                                             let delegate_acc = c.args[1].expr.as_ident().ok_or(PoseidonError::IdentNotFound)?.sym.as_ref();
                                             let auth_acc = c.args[2].expr.as_ident().ok_or(PoseidonError::IdentNotFound)?.sym.as_ref();
@@ -859,6 +867,8 @@ impl ProgramInstruction {
                                             })
                                         },
                                         "approveChecked" => {
+                                              program_mod.add_import("anchor_spl", "token", "approve_checked");
+                                              program_mod.add_import("anchor_spl", "token", "ApproveChecked");
                                             let to_acc = c.args[0].expr.as_ident().ok_or(PoseidonError::IdentNotFound)?.sym.as_ref();
                                             let mint_acc = c.args[1].expr.as_ident().ok_or(PoseidonError::IdentNotFound)?.sym.as_ref();
                                             let delegate_acc = c.args[2].expr.as_ident().ok_or(PoseidonError::IdentNotFound)?.sym.as_ref();
@@ -870,7 +880,9 @@ impl ProgramInstruction {
                                             let delegate_acc_ident = Ident::new(&delegate_acc.to_case(Case::Snake), proc_macro2::Span::call_site());
                                             let auth_acc_ident = Ident::new(&auth_acc.to_case(Case::Snake), proc_macro2::Span::call_site());
                                             let amount_expr = &c.args[4].expr;
+                                            let decimal_expr = &c.args[5].expr;
                                             let amount = ProgramInstruction::get_amount_from_ts_arg(amount_expr)?;
+                                            let decimal = ProgramInstruction::get_amount_from_ts_arg(decimal_expr)?;
                                             ix_body.push(quote!{
                                                 let cpi_ctx = CpiContext::new(
                                                     ctx.accounts.token_program.to_account_info(),
@@ -882,10 +894,12 @@ impl ProgramInstruction {
                                                     },
                                                 );
 
-                                                approve_checked(cpi_ctx, #amount)?;
+                                                approve_checked(cpi_ctx, #amount, #decimal)?;
                                             })
                                         },
                                         "closeAccount" => {
+                                            program_mod.add_import("anchor_spl", "token", "close_account");
+                                            program_mod.add_import("anchor_spl", "token", "CloseAccount");
                                             let acc = c.args[0].expr.as_ident().ok_or(PoseidonError::IdentNotFound)?.sym.as_ref();
                                             let destination_acc = c.args[1].expr.as_ident().ok_or(PoseidonError::IdentNotFound)?.sym.as_ref();
                                             let auth_acc = c.args[2].expr.as_ident().ok_or(PoseidonError::IdentNotFound)?.sym.as_ref();
@@ -906,6 +920,8 @@ impl ProgramInstruction {
                                             })
                                         },
                                         "freezeAccount" => {
+                                            program_mod.add_import("anchor_spl", "token", "freeze_account");
+                                            program_mod.add_import("anchor_spl", "token", "FreezeAccount");
                                             let acc = c.args[0].expr.as_ident().ok_or(PoseidonError::IdentNotFound)?.sym.as_ref();
                                             let mint_acc = c.args[1].expr.as_ident().ok_or(PoseidonError::IdentNotFound)?.sym.as_ref();
                                             let auth_acc = c.args[2].expr.as_ident().ok_or(PoseidonError::IdentNotFound)?.sym.as_ref();
@@ -926,6 +942,8 @@ impl ProgramInstruction {
                                             })
                                         },
                                         "initializeAccount" => {
+                                            program_mod.add_import("anchor_spl", "token", "initialize_account3");
+                                            program_mod.add_import("anchor_spl", "token", "InitializeAccount3");
                                             let acc = c.args[0].expr.as_ident().ok_or(PoseidonError::IdentNotFound)?.sym.as_ref();
                                             let mint_acc = c.args[1].expr.as_ident().ok_or(PoseidonError::IdentNotFound)?.sym.as_ref();
                                             let auth_acc = c.args[2].expr.as_ident().ok_or(PoseidonError::IdentNotFound)?.sym.as_ref();
@@ -946,6 +964,8 @@ impl ProgramInstruction {
                                             })
                                         },
                                         "revoke" => {
+                                            program_mod.add_import("anchor_spl", "token", "revoke");
+                                            program_mod.add_import("anchor_spl", "token", "Revoke");
                                             let source_acc = c.args[0].expr.as_ident().ok_or(PoseidonError::IdentNotFound)?.sym.as_ref();
                                             let auth_acc = c.args[1].expr.as_ident().ok_or(PoseidonError::IdentNotFound)?.sym.as_ref();
                                             let source_acc_ident = Ident::new(&source_acc.to_case(Case::Snake), proc_macro2::Span::call_site());
@@ -963,6 +983,8 @@ impl ProgramInstruction {
                                             })
                                         },
                                         "syncNative" => {
+                                            program_mod.add_import("anchor_spl", "token", "sync_native");
+                                            program_mod.add_import("anchor_spl", "token", "SyncNative");
                                             let acc = c.args[0].expr.as_ident().ok_or(PoseidonError::IdentNotFound)?.sym.as_ref();
                                             let acc_ident = Ident::new(&acc.to_case(Case::Snake), proc_macro2::Span::call_site());
                                             ix_body.push(quote!{
@@ -977,6 +999,8 @@ impl ProgramInstruction {
                                             })
                                         },
                                         "thawAccount" => {
+                                            program_mod.add_import("anchor_spl", "token", "thaw_account");
+                                            program_mod.add_import("anchor_spl", "token", "ThawAccount");
                                             let acc = c.args[0].expr.as_ident().ok_or(PoseidonError::IdentNotFound)?.sym.as_ref();
                                             let mint_acc = c.args[1].expr.as_ident().ok_or(PoseidonError::IdentNotFound)?.sym.as_ref();
                                             let auth_acc = c.args[2].expr.as_ident().ok_or(PoseidonError::IdentNotFound)?.sym.as_ref();
@@ -998,6 +1022,8 @@ impl ProgramInstruction {
                                             })
                                         },
                                         "transferChecked" => {
+                                            program_mod.add_import("anchor_spl", "token", "transfer_checked");
+                                            program_mod.add_import("anchor_spl", "token", "TransferChecked");
                                             let from_acc = c.args[0].expr.as_ident().ok_or(PoseidonError::IdentNotFound)?.sym.as_ref();
                                             let mint_acc = c.args[1].expr.as_ident().ok_or(PoseidonError::IdentNotFound)?.sym.as_ref();
                                             let to_acc = c.args[2].expr.as_ident().ok_or(PoseidonError::IdentNotFound)?.sym.as_ref();
@@ -1007,7 +1033,9 @@ impl ProgramInstruction {
                                             let to_acc_ident = Ident::new(&to_acc.to_case(Case::Snake), proc_macro2::Span::call_site());
                                             let auth_acc_ident = Ident::new(&auth_acc.to_case(Case::Snake), proc_macro2::Span::call_site());
                                             let amount_expr = &c.args[4].expr;
+                                            let decimal_expr = &c.args[5].expr;
                                             let amount = ProgramInstruction::get_amount_from_ts_arg(amount_expr)?;
+                                            let decimal = ProgramInstruction::get_amount_from_ts_arg(decimal_expr)?;
                                             if let Some(cur_ix_acc) = ix_accounts.get(from_acc){
                                                 if cur_ix_acc.seeds.is_some() {
                                                     ix_body.push(quote!{
@@ -1023,7 +1051,7 @@ impl ProgramInstruction {
                                                         ];
                                                         let binding = [&signer_seeds[..]];
                                                         let ctx = CpiContext::new_with_signer(ctx.accounts.token_program.to_account_info(), cpi_accounts, &binding);
-                                                        transfer_checked(ctx, #amount)?;
+                                                        transfer_checked(ctx, #amount, #decimal)?;
                                                     });
                                                 } else {
                                                     ix_body.push(quote!{
@@ -1034,7 +1062,7 @@ impl ProgramInstruction {
                                                             authority: ctx.accounts.#auth_acc_ident.to_account_info(),
                                                         };
                                                         let cpi_ctx = CpiContext::new(ctx.accounts.token_program.to_account_info(), cpi_accounts);
-                                                        transfer_checked(cpi_ctx, #amount)?;
+                                                        transfer_checked(cpi_ctx, #amount, #decimal)?;
                                                     })
                                                 }
                                             }


### PR DESCRIPTION
- There are missing imports when using most SPL functions , this commit fixes that 
 - I also added the missing decimal field to TransferChecked and ApproveChecked , the typescript function took the decimals as a 6th argument , but did not pass it as an argument in the function call
<img width="499" alt="Screenshot 2024-10-27 at 18 12 15" src="https://github.com/user-attachments/assets/d8b211f9-c094-48b0-ace8-abe479390ce9">
<img width="678" alt="Screenshot 2024-10-27 at 18 13 36" src="https://github.com/user-attachments/assets/2e58a42f-0016-4ddd-885c-682544f0c489">
