### PR TITLE
feat: added transpilation instructions to init, close, initIfNeeded

### DIFF
--- a/src/rs_types.rs
+++ b/src/rs_types.rs
@@ -78,6 +78,9 @@ impl InstructionAccount {
         let name = Ident::new(&self.name, proc_macro2::Span::call_site());
         let of_type = &self.of_type;
         let constraints: TokenStream;
+        if self.seeds.is_none() & (self.is_close | self.is_init | self.is_initifneeded) {
+            panic!(r##"use derive or deriveWithBump while using "init" or "initIfNeeded" or "close" "##);
+        }
         let payer = match &self.payer {
             Some(s) => {
                 let payer = Ident::new(s, proc_macro2::Span::call_site());

--- a/src/rs_types.rs
+++ b/src/rs_types.rs
@@ -715,9 +715,7 @@ impl ProgramInstruction {
                                         if chaincall1prop == "init" {
                                             ix.uses_system_program = true;
                                             cur_ix_acc.is_init = true;
-                                            if let Some(payer) = &ix.signer {
-                                                cur_ix_acc.payer = Some(payer.clone());
-                                            }
+                                            cur_ix_acc.payer = Some(c.args[0].expr.as_ident().ok_or(PoseidonError::IdentNotFound)?.sym.as_ref().to_case(Case::Snake));
                                         }
                                         else if chaincall1prop == "initIfNeeded" {
                                             ix.uses_system_program = true;
@@ -742,9 +740,7 @@ impl ProgramInstruction {
                                     } else if prop.contains("init") {
                                         ix.uses_system_program = true;
                                         cur_ix_acc.is_init = true;
-                                        if let Some(payer) = &ix.signer {
-                                            cur_ix_acc.payer = Some(payer.clone());
-                                        }
+                                        cur_ix_acc.payer = Some(c.args[0].expr.as_ident().ok_or(PoseidonError::IdentNotFound)?.sym.as_ref().to_case(Case::Snake));
                                     } else if prop.contains("initIfNeeded") {
                                         ix.uses_system_program = true;
                                         cur_ix_acc.is_initifneeded = true;
@@ -1573,7 +1569,7 @@ impl ProgramAccount {
 
                 if field_type.contains("Pubkey") {
                     space += 32 * len;
-                } else if field_type.contains("u64") | field_type.contains("u64") {
+                } else if field_type.contains("u64") | field_type.contains("i64") {
                     space += 8 * len;
                 } else if field_type.contains("u32") | field_type.contains("i32") {
                     space += 4 * len;

--- a/src/rs_types.rs
+++ b/src/rs_types.rs
@@ -739,6 +739,21 @@ impl ProgramInstruction {
                                             cur_ix_acc.has_one = has_one;
 
                                         }
+                                    } else if prop.contains("init") {
+                                        ix.uses_system_program = true;
+                                        cur_ix_acc.is_init = true;
+                                        if let Some(payer) = &ix.signer {
+                                            cur_ix_acc.payer = Some(payer.clone());
+                                        }
+                                    } else if prop.contains("initIfNeeded") {
+                                        ix.uses_system_program = true;
+                                        cur_ix_acc.is_initifneeded = true;
+                                        if let Some(payer) = &ix.signer {
+                                            cur_ix_acc.payer = Some(payer.clone());
+                                        }
+                                    } else if prop.contains("close") {
+                                        cur_ix_acc.close = Some(c.args[0].expr.as_ident().ok_or(PoseidonError::IdentNotFound)?.sym.as_ref().to_case(Case::Snake));
+                                        cur_ix_acc.is_mut = true;
                                     }
                                 }
                                 if obj == "SystemProgram" {


### PR DESCRIPTION
### Add support for `init`, `initIfNeeded`, and `close` properties 

This PR adds these method in rs_types.rs to handle additional properties: `init`, `initIfNeeded`, and `close`.

#### Changes:
- **`init` Property**:
  - Sets `ix.uses_system_program to `true.
  - Marks `cur_ix_acc.is_init` as `true`.
  - Sets `cur_ix_acc.payer` if a signer is present.

- **`initIfNeeded` Property**:
  - Sets `ix.uses_system_program` to `true`.
  - Marks `cur_ix_acc.is_initifneeded` as `true`.
  - Sets `cur_ix_acc.payer` if a signer is present.

- **`close` Property**:
  - Sets `cur_ix_acc.close` to the snake_case version of the provided argument.
  - Marks `cur_ix_acc.is_mut` as `true`.

These changes improve the flexibility and functionality of the implementation, allowing it to handle more complex scenarios without `derive`.



Issue:
```
import {
  Account,
  i64,
  Pubkey,
  Signer,
  u8,
  type Result,
} from "@solanaturbine/poseidon";

export default class VoteProgram {
  static PROGRAM_ID = new Pubkey(
    "H1MpV9PqZ2knzDhhp8knjATvrqLQyyiUdc4CatPcQ3KK"
  );

  // Pass all the accounts we need as the parameters
  initialize(state: VoteState, user: Signer): Result {
    // Use `.derive([seed])` to define the PDA and chain the `.init()` at the end for creating the account
    state.derive(["vote"]).init();

    // Set the initial value to the `vote` field of the account
    state.vote = new i64(0);
  }

  upvote(state: VoteState): Result {
    state.derive(["vote"]);
    state.vote = state.vote.add(1);
  }

  downvote(state: VoteState): Result {
    state.derive(["vote"]);
    state.vote = state.vote.sub(1);
  }

  closevote(state: VoteState, user: Signer): Result {
    state.derive(["vote"]);
    state.close(user);
  }
}

export interface VoteState extends Account {
  vote: i64; // This field store the voting result
  bump: u8; // bump is for PDA (program derieved account, a special type of account which controlled by program on Solana)
}
```
Above worked perfectly but
```
import {
  Account,
  i64,
  Pubkey,
  Signer,
  u8,
  type Result,
} from "@solanaturbine/poseidon";

export default class VoteProgram {
  static PROGRAM_ID = new Pubkey(
    "H1MpV9PqZ2knzDhhp8knjATvrqLQyyiUdc4CatPcQ3KK"
  );

  // Pass all the accounts we need as the parameters
  initialize(state: VoteState, user: Signer): Result {
    // Use `.derive([seed])` to define the PDA and chain the `.init()` at the end for creating the account
    state.init();

    // Set the initial value to the `vote` field of the account
    state.vote = new i64(0);
  }

  upvote(state: VoteState): Result {
    state.vote = state.vote.add(1);
  }

  downvote(state: VoteState): Result {
    state.vote = state.vote.sub(1);
  }

  closevote(state: VoteState, user: Signer): Result {
    state.close(user);
  }
}

export interface VoteState extends Account {
  vote: i64; // This field store the voting result
  bump: u8; // bump is for PDA (program derieved account, a special type of account which controlled by program on Solana)
}
```
didn't work









