### PR TITLE
feat: building, testing and syncing program keys

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -866,6 +866,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a26ae43d7bcc3b814de94796a5e736d4029efb0ee900c12e2d54c993ad1a1e07"
 
 [[package]]
+name = "equivalent"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
+
+[[package]]
 name = "feature-probe"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -948,6 +954,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "hashbrown"
+version = "0.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a9bfc1af68b1726ea47d3d5109de126281def866b33970e10fbab11b5dafab3"
+
+[[package]]
 name = "heck"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1016,6 +1028,16 @@ dependencies = [
  "sized-chunks",
  "typenum",
  "version_check",
+]
+
+[[package]]
+name = "indexmap"
+version = "2.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "707907fe3c25f5424cce2cb7e1cbcafee6bdbe735ca90ef77c29e84591e5b9da"
+dependencies = [
+ "equivalent",
+ "hashbrown 0.15.1",
 ]
 
 [[package]]
@@ -1347,6 +1369,8 @@ dependencies = [
  "swc_ecma_ast",
  "swc_ecma_parser",
  "thiserror",
+ "toml 0.8.19",
+ "walkdir",
 ]
 
 [[package]]
@@ -1377,7 +1401,7 @@ version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d6ea3c4595b96363c13943497db34af4460fb474a95c43f4446ad341b8c9785"
 dependencies = [
- "toml",
+ "toml 0.5.11",
 ]
 
 [[package]]
@@ -1584,6 +1608,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f3cb5ba0dc43242ce17de99c180e96db90b235b8a9fdc9543c96d2209116bd9f"
 
 [[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
+]
+
+[[package]]
 name = "scoped-tls"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1638,6 +1671,15 @@ checksum = "cb0652c533506ad7a2e353cce269330d6afd8bdfb6d75e0ace5b35aacbd7b9e9"
 dependencies = [
  "itoa",
  "ryu",
+ "serde",
+]
+
+[[package]]
+name = "serde_spanned"
+version = "0.6.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87607cb1398ed59d48732e575a4c28a7a8ebf2454b964fe3f224f2afc07909e1"
+dependencies = [
  "serde",
 ]
 
@@ -2114,6 +2156,40 @@ dependencies = [
 ]
 
 [[package]]
+name = "toml"
+version = "0.8.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1ed1f98e3fdc28d6d910e6737ae6ab1a93bf1985935a1193e68f93eeb68d24e"
+dependencies = [
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_edit",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "0.6.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0dd7358ecb8fc2f8d014bf86f6f638ce72ba252a2c3a2572f2a795f1d23efb41"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.22.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ae48d6208a266e853d946088ed816055e556cc6028c5e8e2b84d9fa5dd7c7f5"
+dependencies = [
+ "indexmap",
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "winnow",
+]
+
+[[package]]
 name = "tracing"
 version = "0.1.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2227,6 +2303,16 @@ name = "version_check"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
+
+[[package]]
+name = "walkdir"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
+dependencies = [
+ "same-file",
+ "winapi-util",
+]
 
 [[package]]
 name = "wasi"
@@ -2464,6 +2550,15 @@ name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "winnow"
+version = "0.6.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "36c1fec1a2bb5866f07c25f68c26e565c4c200aebb96d7e55710c19d3e8ac49b"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "zerocopy"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,3 +16,5 @@ rust-format = { version = "0.3.4", features = ["pretty_please"] }
 anchor-lang = { version = "0.30.0", features = ["init-if-needed"]}
 clap = { version = "4.4.8", features = ["derive", "cargo"] }
 regex = "1.11.0"
+walkdir = "2.3"
+toml = "0.8.0"

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -210,7 +210,8 @@ pub fn sync_program_ids() -> Result<()> {
     }
 
     for (program_name, program_id) in program_ids {
-        let ts_file = ts_programs_dir.join(format!("{}.ts", program_name));
+        let ts_program_file_name = program_name.to_case(Case::Camel);
+        let ts_file = ts_programs_dir.join(format!("{}.ts", ts_program_file_name));
         if !ts_file.exists() {
             println!("Warning: TypeScript file not found for program: {}", program_name);
             continue;

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -62,7 +62,8 @@ pub fn init(name: &String) {
         )
     });
 
-    let program_file_name = name.to_case(Case::Camel);
+    let ts_program_file_name = name.to_case(Case::Camel);
+    let toml_program_name = name.to_case(Case::Snake);
 
     // Get the generated program ID from Anchor.toml
     let anchor_toml_path = project_path.join("Anchor.toml");
@@ -72,12 +73,12 @@ pub fn init(name: &String) {
     let program_ids = extract_program_ids(&anchor_toml)
         .unwrap_or_else(|_| panic!("Failed to extract program IDs from Anchor.toml"));
 
-    let program_id = program_ids.get(name)
+    let program_id = program_ids.get(&toml_program_name)
         .unwrap_or_else(|| panic!("Program ID not found for {}", name));
 
     // Create the ts-programs src/{programName}.ts file and add default content
     let ts_programs_src_program_path =
-        ts_programs_src_path.join(format!("{}.ts", program_file_name));
+        ts_programs_src_path.join(format!("{}.ts", ts_program_file_name));
     fs::write(
         &ts_programs_src_program_path,
         get_default_program_content(&name, &program_id),
@@ -85,7 +86,7 @@ pub fn init(name: &String) {
     .unwrap_or_else(|_| {
         panic!(
             "Failed to create {} file at {:?}",
-            program_file_name, ts_programs_src_program_path
+            ts_program_file_name, ts_programs_src_program_path
         )
     });
 
@@ -122,6 +123,8 @@ pub fn build_workspace() -> Result<()> {
         }
 
         let program_name = get_program_name_from_cargo(&cargo_path)?;
+        let ts_program_file_name = program_name.to_case(Case::Camel);
+
         println!("Found program: {}", program_name);
 
         // Create/ensure src directory exists
@@ -132,7 +135,7 @@ pub fn build_workspace() -> Result<()> {
         // Look for corresponding TypeScript file
         let ts_file = PathBuf::from("ts-programs")
             .join("src")
-            .join(format!("{}.ts", program_name));
+            .join(format!("{}.ts", ts_program_file_name));
 
         if !ts_file.exists() {
             println!("Warning: No TypeScript file found at {}", ts_file.display());

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,12 +1,15 @@
 use std::{
-    env, fs,
-    io::{BufRead, BufReader},
-    path::Path,
-    process::{Command, Stdio},
+    collections::HashMap, env, fs, io::{BufRead, BufReader}, path::{Path, PathBuf}, process::{Command, Stdio}
 };
 
+use anyhow::{Context, Result};
 use convert_case::{Case, Casing};
-use regex::Regex;
+use regex::{RegexBuilder, Regex};
+use swc_ecma_ast::Module;
+use toml::Value;
+
+use crate::parse_ts::parse_ts;
+use crate::transpiler::transpile;
 
 pub fn init(name: &String) {
     println!("Initializing project: {}", name);
@@ -48,7 +51,7 @@ pub fn init(name: &String) {
 
     execute_cmd(Command::new("npm").args(["add", "@solanaturbine/poseidon"]));
 
-    env::set_current_dir(original_dir).expect("Failed to change directory back to original");
+    env::set_current_dir(&original_dir).expect("Failed to change directory back to original");
 
     // Create the ts-programs src directory
     let ts_programs_src_path = ts_programs_path.join("src");
@@ -61,12 +64,23 @@ pub fn init(name: &String) {
 
     let program_file_name = name.to_case(Case::Camel);
 
+    // Get the generated program ID from Anchor.toml
+    let anchor_toml_path = project_path.join("Anchor.toml");
+    let anchor_toml = fs::read_to_string(&anchor_toml_path)
+        .unwrap_or_else(|_| panic!("Failed to read Anchor.toml"));
+
+    let program_ids = extract_program_ids(&anchor_toml)
+        .unwrap_or_else(|_| panic!("Failed to extract program IDs from Anchor.toml"));
+
+    let program_id = program_ids.get(name)
+        .unwrap_or_else(|| panic!("Program ID not found for {}", name));
+
     // Create the ts-programs src/{programName}.ts file and add default content
     let ts_programs_src_program_path =
         ts_programs_src_path.join(format!("{}.ts", program_file_name));
     fs::write(
         &ts_programs_src_program_path,
-        get_default_program_content(&name),
+        get_default_program_content(&name, &program_id),
     )
     .unwrap_or_else(|_| {
         panic!(
@@ -81,6 +95,200 @@ pub fn init(name: &String) {
     );
 }
 
+pub fn build_workspace() -> Result<()> {
+    // Verify we're in a workspace root
+    if !Path::new("Anchor.toml").exists() {
+        return Err(anyhow::anyhow!("Anchor.toml not found. Are you in the workspace root?"));
+    }
+
+    // Get all programs from the programs directory
+    let programs_dir = PathBuf::from("programs");
+    if !programs_dir.exists() {
+        return Err(anyhow::anyhow!("programs directory not found"));
+    }
+
+    // Process each program in the programs directory
+    for program_entry in fs::read_dir(&programs_dir)? {
+        let program_dir = program_entry?.path();
+        if !program_dir.is_dir() {
+            continue;
+        }
+
+        // Read program name from Cargo.toml
+        let cargo_path = program_dir.join("Cargo.toml");
+        if !cargo_path.exists() {
+            println!("Warning: Cargo.toml not found in {}", program_dir.display());
+            continue;
+        }
+
+        let program_name = get_program_name_from_cargo(&cargo_path)?;
+        println!("Found program: {}", program_name);
+
+        // Create/ensure src directory exists
+        let src_dir = program_dir.join("src");
+        fs::create_dir_all(&src_dir)
+            .context(format!("Failed to create src directory for {}", program_name))?;
+
+        // Look for corresponding TypeScript file
+        let ts_file = PathBuf::from("ts-programs")
+            .join("src")
+            .join(format!("{}.ts", program_name));
+
+        if !ts_file.exists() {
+            println!("Warning: No TypeScript file found at {}", ts_file.display());
+            continue;
+        }
+
+        // Compile TypeScript to Rust
+        let rs_file = src_dir.join("lib.rs");
+        println!("Compiling {} to {}", ts_file.display(), rs_file.display());
+
+        let module: Module = parse_ts(&ts_file.to_string_lossy().to_string());
+        transpile(&module, &rs_file.to_string_lossy().to_string())?;
+
+        println!("Successfully compiled {}", program_name);
+    }
+
+    println!("Build completed successfully!");
+    Ok(())
+}
+
+pub fn run_tests() -> Result<()> {
+    // Verify we're in a workspace root by checking for Anchor.toml
+    if !Path::new("Anchor.toml").exists() {
+        return Err(anyhow::anyhow!("Anchor.toml not found. Are you in the workspace root?"));
+    }
+
+    println!("Running anchor tests...");
+
+    // Build the workspace first
+    build_workspace()?;
+
+    // Execute anchor test
+    let mut cmd = Command::new("anchor");
+    cmd.arg("test");
+
+    // Stream the test output
+    let output = execute_cmd_with_output(&mut cmd)
+        .context("Failed to execute anchor test command")?;
+
+    // Check if tests passed
+    if output.status.success() {
+        println!("\nTests completed successfully! ✨");
+        Ok(())
+    } else {
+        Err(anyhow::anyhow!("Tests failed"))
+    }
+}
+
+pub fn sync_program_ids() -> Result<()> {
+    println!("Syncing program IDs...");
+
+    // First run anchor keys sync
+    let mut cmd = Command::new("anchor");
+    cmd.args(["keys", "sync"]);
+
+    let output = execute_cmd_with_output(&mut cmd)
+        .context("Failed to execute 'anchor keys sync'")?;
+
+    if !output.status.success() {
+        return Err(anyhow::anyhow!("Failed to run 'anchor keys sync'"));
+    }
+
+    // Read program IDs from Anchor.toml
+    let anchor_toml = fs::read_to_string("Anchor.toml")
+        .context("Failed to read Anchor.toml")?;
+    let program_ids = extract_program_ids(&anchor_toml)?;
+
+    // Update TypeScript files
+    let ts_programs_dir = PathBuf::from("ts-programs").join("src");
+    if !ts_programs_dir.exists() {
+        return Err(anyhow::anyhow!("ts-programs/src directory not found"));
+    }
+
+    for (program_name, program_id) in program_ids {
+        let ts_file = ts_programs_dir.join(format!("{}.ts", program_name));
+        if !ts_file.exists() {
+            println!("Warning: TypeScript file not found for program: {}", program_name);
+            continue;
+        }
+
+        update_program_id_in_ts(&ts_file, &program_id)
+            .context(format!("Failed to update program ID in {}.ts", program_name))?;
+
+        println!("Updated program ID for {} to {}", program_name, program_id);
+    }
+
+    println!("Program IDs synced successfully! ✨");
+    Ok(())
+}
+
+fn extract_program_ids(anchor_toml: &str) -> Result<HashMap<String, String>> {
+    let toml_value: Value = anchor_toml.parse()
+        .context("Failed to parse Anchor.toml")?;
+
+    let mut program_ids = HashMap::new();
+
+    if let Some(programs) = toml_value
+        .get("programs")
+        .and_then(|p| p.get("localnet"))
+        .and_then(|l| l.as_table())
+    {
+        for (name, value) in programs {
+            if let Some(program_id) = value.as_str() {
+                program_ids.insert(name.clone(), program_id.to_string());
+            }
+        }
+    }
+
+    if program_ids.is_empty() {
+        return Err(anyhow::anyhow!("No program IDs found in Anchor.toml"));
+    }
+
+    Ok(program_ids)
+}
+
+fn update_program_id_in_ts(file_path: &Path, program_id: &str) -> Result<()> {
+    let content = fs::read_to_string(file_path)
+        .context("Failed to read TypeScript file")?;
+
+    // Create a regex that matches both possible patterns
+    let re = RegexBuilder::new(r#"static PROGRAM_ID = new Pubkey\("([^"]*)"\)"#)
+        .case_insensitive(true)
+        .build()
+        .context("Failed to create regex")?;
+
+    let new_content = if let Some(capture) = re.captures(&content) {
+        // Replace the program ID while preserving the exact casing and spacing
+        content.replace(&capture[0], &format!(r#"static PROGRAM_ID = new Pubkey("{}")"#, program_id))
+    } else {
+        println!("Warning: PROGRAM_ID not found in expected format in {}", file_path.display());
+        content
+    };
+
+    fs::write(file_path, new_content)
+        .context("Failed to write updated TypeScript file")?;
+
+    Ok(())
+}
+
+fn get_program_name_from_cargo(cargo_path: &Path) -> Result<String> {
+    let content = fs::read_to_string(cargo_path)
+        .context("Failed to read Cargo.toml")?;
+
+    let cargo_toml: Value = content.parse()
+        .context("Failed to parse Cargo.toml")?;
+
+    // Get the package name from Cargo.toml
+    let package_name = cargo_toml
+        .get("package")
+        .and_then(|package| package.get("name"))
+        .and_then(|name| name.as_str())
+        .ok_or_else(|| anyhow::anyhow!("Failed to get package name from Cargo.toml"))?;
+
+    Ok(package_name.to_string())
+}
+
 fn anchor_installed() -> bool {
     Command::new("anchor")
         .arg("--version")
@@ -91,6 +299,17 @@ fn anchor_installed() -> bool {
 fn is_valid_project_name(name: &str) -> bool {
     let re = Regex::new(r"^[a-zA-Z][a-zA-Z0-9\-]*$").unwrap();
     re.is_match(name)
+}
+
+/// Executes a command and streams the output to stdout, returning the output
+fn execute_cmd_with_output(cmd: &mut Command) -> Result<std::process::Output> {
+    let output = cmd
+        .stdout(Stdio::inherit())
+        .stderr(Stdio::inherit())
+        .output()
+        .context("Failed to execute command")?;
+
+    Ok(output)
 }
 
 /// Executes a command and streams the output to stdout.
@@ -109,17 +328,18 @@ fn execute_cmd(cmd: &mut Command) {
     }
 }
 
-fn get_default_program_content(program_name: &str) -> String {
+fn get_default_program_content(program_name: &str, program_id: &str) -> String {
     format!(
         r#"import {{ Pubkey, type Result }} from "@solanaturbine/poseidon";
 
 export default class {} {{
-    static PROGRAM_ID = new Pubkey("11111111111111111111111111111111");
+    static PROGRAM_ID = new Pubkey("{}");
 
     initialize(): Result {{
         // Write your program here
     }}
 }}"#,
-        program_name.to_case(Case::Pascal)
+        program_name.to_case(Case::Pascal),
+        program_id
     )
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -10,7 +10,7 @@ use clap::{Parser as ClapParser, Subcommand};
 use parse_ts::parse_ts;
 use swc_ecma_ast::Module;
 
-use cli::init;
+use cli::{init, build_workspace, run_tests, sync_program_ids};
 use transpiler::transpile;
 
 #[derive(ClapParser, Debug)]
@@ -23,6 +23,12 @@ struct Cli {
 
 #[derive(Subcommand, Debug)]
 enum Commands {
+    /// Build Typescript programs in workspace
+    Build,
+    /// Run anchor tests in the workspace
+    Test,
+    /// Sync anchor keys in poseidon programs
+    Sync,
     /// Transpile a Typescript program to a Rust program
     Compile {
         /// Input Typescript file path
@@ -43,6 +49,15 @@ fn main() -> Result<()> {
     let cli = Cli::parse();
 
     match &cli.command {
+        Commands::Sync => {
+            sync_program_ids()?;
+        }
+        Commands::Test => {
+            run_tests()?;
+        }
+        Commands::Build => {
+            build_workspace()?;
+        }
         Commands::Compile { input, output } => {
             let module: Module = parse_ts(input);
             transpile(&module, output)?;


### PR DESCRIPTION
- Build command (`poseidon build`) - compiles ts-programs/ dir into programs/src without providing file paths
- Test command (`poseidon test`) - executes anchor test in that directory
- Sync command (`poseidon sync`) - executes `anchor keys sync` and then updates the ts program