### PR TITLE
Add create_metadata_v3

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,0 @@
-{
-    "CodeGPT.apiKey": "Ollama"
-}

--- a/src/rs_types.rs
+++ b/src/rs_types.rs
@@ -1444,6 +1444,64 @@ impl ProgramInstruction {
                                         _ => {}
                                     }
                                 }
+                                if obj == "metadataProgram" {
+                                    match prop {
+                                        "createMetadataAccountsV3" => {
+                                            program_mod.add_import("anchor_spl", "metadata", "create_metadata_accounts_v3");
+                                            program_mod.add_import("anchor_spl", "metadata", "CreateMetdataAccountsV3");
+                                            program_mod.add_import("anchor_spl", "metadata","Metadata");
+                                            program_mod.add_import("anchor_spl", "metadata", "mpl_token_metadata::types::DataV2");
+                                            program_mod.add_import("anchor_spl", "token", "Token");
+                                            program_mod.add_import("anchor_spl", "token", "Mint");
+                                            let payer_acc = c.args[0].expr.as_ident().ok_or(PoseidonError::IdentNotFound)?.sym.as_ref();
+                                            let update_authority_acc = c.args[1].expr.as_ident().ok_or(PoseidonError::IdentNotFound)?.sym.as_ref();
+                                            let mint_acc = c.args[2].expr.as_ident().ok_or(PoseidonError::IdentNotFound)?.sym.as_ref();
+                                            let metadata_acc = c.args[3].expr.as_ident().ok_or(PoseidonError::IdentNotFound)?.sym.as_ref();
+                                            let mint_authority_acc = c.args[4].expr.as_ident().ok_or(PoseidonError::IdentNotFound)?.sym.as_ref();
+                                            let rent_acc = c.args[5].expr.as_ident().ok_or(PoseidonError::IdentNotFound)?.sym.as_ref();
+                                            
+                                            let payer_acc_ident = Ident::new(&payer_acc.to_case(Case::Snake), proc_macro2::Span::call_site());
+                                            let update_authority_acc_ident = Ident::new(&update_authority_acc.to_case(Case::Snake), proc_macro2::Span::call_site());
+                                            let mint_acc_ident = Ident::new(&mint_acc.to_case(Case::Snake), proc_macro2::Span::call_site());
+                                            let metadata_acc_ident = Ident::new(&metadata_acc.to_case(Case::Snake), proc_macro2::Span::call_site());
+                                            let mint_authority_acc_ident = Ident::new(&mint_authority_acc.to_case(Case::Snake), proc_macro2::Span::call_site());
+                                            // let decimal_expr = &c.args[5].expr;
+
+                                            // let decimal = ProgramInstruction::get_rs_arg_from_ts_arg(&ix_accounts, decimal_expr)?;
+                                            // let decimal = ProgramInstruction::get_rs_hashmap_from_ts_arg(&ix_accounts, decimal_expr)?;   
+                                            //will add one with signer later 
+                                            ix_body.push(quote!{
+                                                        let token_data: DataV2 = DataV2 {
+                                                            name: metadata.name,
+                                                            symbol: metadata.symbol,
+                                                            uri: metadata.uri,
+                                                            seller_fee_basis_points: 0,
+                                                            creators: None,
+                                                            collection: None,
+                                                            uses: None,
+                                                        };
+                                                        let cpi_accounts = CreateMetadataAccountsV3 {
+                                                            payer: ctx.accounts.#payer_acc_ident.to_account_info(),
+                                                            update_authority: ctx.accounts.#update_authority_acc_ident.to_account_info(),
+                                                            mint: ctx.accounts.#mint_acc_ident.to_account_info(),
+                                                            metadata: ctx.accounts.#metadata_acc_ident.to_account_info(),
+                                                            mint_authority: ctx.accounts.#mint_authority_acc_ident.to_account_info(),
+                                                            system_program: ctx.accounts.system_program.to_account_info(),
+                                                            rent: ctx.accounts.rent.to_account_info(),
+                                                        };
+                                                        let cpi_ctx = CpiContext::new(ctx.accounts.token_program.to_account_info(), cpi_accounts);
+                                                        create_metadata_accounts_v3(
+                                                            cpi_ctx, 
+                                                            token_data,
+                                                            //is_mutable,
+                                                            //update_authority_is_signer,
+
+                                                        )?;
+                                            })
+                                        }
+                                        _ => ()
+                                    }
+                                }
                             }
                             Expr::Assign(a) => {
                                 // let op = a.op;

--- a/src/rs_types.rs
+++ b/src/rs_types.rs
@@ -617,12 +617,15 @@ impl ProgramInstruction {
                         name.clone(),
                         InstructionAccount::new(
                             snaked_name.clone(),
-                            quote! { Account<'info, Metadata> },
+                            quote! { 
+                                UncheckedAccount<'info>
+                            },
                             of_type,
                             optional,
                         ),
                     );
                     ix.uses_token_program = true;
+                    ix.uses_system_program = true;
                     ix.uses_token_metadata_program = true; 
                     program_mod.add_import("anchor_spl", "metadata", "mpl_token_metadata");
                     program_mod.add_import("anchor_spl", "token", "Token");
@@ -1621,12 +1624,12 @@ impl ProgramInstruction {
                                                             payer: ctx.accounts.#payer_acc_ident.to_account_info(),
                                                             update_authority: ctx.accounts.#update_authority_acc_ident.to_account_info(),
                                                             mint: ctx.accounts.#mint_acc_ident.to_account_info(),
-                                                            metadata: ctx.accounts.metadata.to_account_info(),
+                                                            metadata: ctx.accounts.metadata_account.to_account_info(),
                                                             mint_authority: ctx.accounts.#mint_authority_acc_ident.to_account_info(),
                                                             system_program: ctx.accounts.system_program.to_account_info(),
                                                             rent: ctx.accounts.rent.to_account_info(),
                                                         };
-                                                        let cpi_ctx = CpiContext::new(ctx.accounts.token_program.to_account_info(), cpi_accounts);
+                                                        let cpi_ctx = CpiContext::new(ctx.accounts.token_metadata_program.to_account_info(), cpi_accounts);
                                                         create_metadata_accounts_v3(
                                                             cpi_ctx, 
                                                             token_data,
@@ -1869,7 +1872,7 @@ impl ProgramInstruction {
         }
         if self.uses_token_metadata_program {
             accounts.push(quote! {
-                 pub token_metadata_program: Program<'info, mpl_token_metadata::accounts::Metadata>,
+                 pub token_metadata_program: Program<'info, Metadata>,
             });
             // if it doesn't weirdly mess up the TokenStream or give stupid errors then we can put them in one quote macro 
             accounts.push(quote! {

--- a/src/ts_types.rs
+++ b/src/ts_types.rs
@@ -37,12 +37,13 @@ pub const STANDARD_ARRAY_TYPES: [&str; 13] = [
     "Vec<Boolean>",
 ];
 
-pub const STANDARD_ACCOUNT_TYPES: [&str; 7] = [
+pub const STANDARD_ACCOUNT_TYPES: [&str; 8] = [
     "Signer",
     "UncheckedAccount",
     "AccountInfo",
     "TokenAccount",
     "SystemAccount",
+    "Metadata", //ideally it should be MetadataAccount but in the docs its just Metadata so i'm following that 
     "AssociatedTokenAccount",
     "Mint",
 ];


### PR DESCRIPTION
So this pull request adds a couple of changes 

- add create_metadata_v3 so we can create NFTs and custom tokens 
- adds custom constraints for the mint type 
- adds seeds::program constraint 

a demo of how to use it is here [example repo](https://github.com/adpthegreat/Solana-Learning/tree/main/poseidon/testing)

@ShrinathNR I've also added the corresponding types in the poseidon types , please review , thank you